### PR TITLE
fix: updating reward denom is forbidden

### DIFF
--- a/contracts/anchor_basset_rewards_dispatcher/src/contract.rs
+++ b/contracts/anchor_basset_rewards_dispatcher/src/contract.rs
@@ -137,18 +137,16 @@ pub fn execute_update_config(
         })?;
     }
 
-    if let Some(s) = stluna_reward_denom {
-        CONFIG.update(deps.storage, |mut last_config| -> StdResult<_> {
-            last_config.stluna_reward_denom = s;
-            Ok(last_config)
-        })?;
+    if let Some(_s) = stluna_reward_denom {
+        return Err(StdError::generic_err(
+            "updating stluna reward denom is forbidden",
+        ));
     }
 
-    if let Some(b) = bluna_reward_denom {
-        CONFIG.update(deps.storage, |mut last_config| -> StdResult<_> {
-            last_config.bluna_reward_denom = b;
-            Ok(last_config)
-        })?;
+    if let Some(_b) = bluna_reward_denom {
+        return Err(StdError::generic_err(
+            "updating bluna reward denom is forbidden",
+        ));
     }
 
     if let Some(r) = lido_fee_rate {

--- a/contracts/anchor_basset_rewards_dispatcher/src/testing/tests.rs
+++ b/contracts/anchor_basset_rewards_dispatcher/src/testing/tests.rs
@@ -391,10 +391,16 @@ fn test_update_config() {
     };
     let info = mock_info(&new_owner, &[]);
     let res = execute(deps.as_mut(), mock_env(), info, update_config_msg);
-    assert!(res.is_ok());
+    assert!(res.is_err());
+    assert_eq!(
+        Some(StdError::generic_err(
+            "updating stluna reward denom is forbidden"
+        )),
+        res.err()
+    );
 
     let config = CONFIG.load(&deps.storage).unwrap();
-    assert_eq!(String::from("new_denom"), config.stluna_reward_denom);
+    assert_eq!(String::from("uluna"), config.stluna_reward_denom);
 
     // change bluna_reward_denom
     let update_config_msg = ExecuteMsg::UpdateConfig {
@@ -408,10 +414,16 @@ fn test_update_config() {
     };
     let info = mock_info(&new_owner, &[]);
     let res = execute(deps.as_mut(), mock_env(), info, update_config_msg);
-    assert!(res.is_ok());
+    assert!(res.is_err());
+    assert_eq!(
+        Some(StdError::generic_err(
+            "updating bluna reward denom is forbidden"
+        )),
+        res.err()
+    );
 
     let config = CONFIG.load(&deps.storage).unwrap();
-    assert_eq!(String::from("new_denom"), config.bluna_reward_denom);
+    assert_eq!(String::from("uusd"), config.bluna_reward_denom);
 
     // change lido_fee_address
     let update_config_msg = ExecuteMsg::UpdateConfig {


### PR DESCRIPTION
the contract returnы an error in case of attempt to update stluna/bluna reward denom

the second way is use string constants as stluna/bluna denom